### PR TITLE
update platform lock for rocksdb migration

### DIFF
--- a/constants.js
+++ b/constants.js
@@ -24,7 +24,7 @@ const IPC_ID = 'pear'
 const PLATFORM_URL = LOCALDEV ? new URL('pear/', swapURL) : new URL('../../../', swapURL)
 
 const PLATFORM_DIR = toPath(PLATFORM_URL)
-const PLATFORM_LOCK = toPath(new URL('corestores/platform/primary-key', PLATFORM_URL))
+const PLATFORM_LOCK = toPath(new URL('corestores/platform/LOCK', PLATFORM_URL))
 
 const RUNTIME_EXEC = isWindows
   ? 'pear-runtime.exe'


### PR DESCRIPTION
Blocked by https://github.com/holepunchto/pear/pull/638