### PR TITLE
Remove electron exit

### DIFF
--- a/index.js
+++ b/index.js
@@ -187,12 +187,8 @@ class API {
       if (rejected) {
         console.error(`${rejected}. User teardown threw. Exiting...`)
       }
-      if (global.Bare) {
-        global.Bare.exit()
-      } else {
-        const electron = require('electron')
-        electron.ipcRenderer.send('app-exit') // graceful electron shutdown
-      }
+
+      program.exit()
     }
   }
 


### PR DESCRIPTION
We no longer need this with pear-runtime and the conditional `require('electron')` prevents bare-build and bare-bundle from working in pear.